### PR TITLE
Support lazy injection.

### DIFF
--- a/injector.go
+++ b/injector.go
@@ -106,6 +106,7 @@ func (self *Injector) get(key providerKey) (interface{}, error) {
 	}
 
 	outputs, err := callProviderhandlingLazyErrors(provider.provider, arguments)
+	fmt.Println("~~~~~~~~ PT 1")
 	if err != nil {
 		return nil, provideError{key: key, cause: err}
 	}
@@ -131,7 +132,7 @@ func callProviderhandlingLazyErrors(
 			if err, ok := err.(lazyProviderError); ok {
 				resultingErr = err.cause
 			} else {
-				// This panic indicates a bug in Injector code.
+				fmt.Println("~~~~~~~ paniced")
 				panic(err)
 			}
 		}

--- a/injector.go
+++ b/injector.go
@@ -131,6 +131,7 @@ func callProviderhandlingLazyErrors(
 			if err, ok := err.(lazyProviderError); ok {
 				resultingErr = err.cause
 			} else {
+				// This panic indicates a bug in Injector code.
 				panic(err)
 			}
 		}

--- a/injector.go
+++ b/injector.go
@@ -105,8 +105,7 @@ func (self *Injector) get(key providerKey) (interface{}, error) {
 		arguments[offset+1] = reflect.Zero(argumentKey.annotationType)
 	}
 
-	outputs, err := callProviderhandlingLazyErrors(provider.provider, arguments)
-	fmt.Println("~~~~~~~~ PT 1")
+	outputs, err := callProviderHandlingLazyErrors(provider.provider, arguments)
 	if err != nil {
 		return nil, provideError{key: key, cause: err}
 	}
@@ -123,16 +122,15 @@ func (self *Injector) get(key providerKey) (interface{}, error) {
 	}
 }
 
-func callProviderhandlingLazyErrors(
+func callProviderHandlingLazyErrors(
 	provider reflect.Value,
 	arguments []reflect.Value,
 ) (result []reflect.Value, resultingErr error) {
 	defer func() {
 		if err := recover(); err != nil {
-			if err, ok := err.(lazyProviderError); ok {
-				resultingErr = err.cause
+			if lazyProviderErr, ok := err.(lazyProviderError); ok {
+				resultingErr = lazyProviderErr.cause
 			} else {
-				fmt.Println("~~~~~~~ paniced")
 				panic(err)
 			}
 		}

--- a/injector_test.go
+++ b/injector_test.go
@@ -93,6 +93,65 @@ func (self *InjectorTests) TestGetNil() {
 	self.Nil(value)
 }
 
+func (self *InjectorTests) TestErrorGet() {
+	self.initInjector(&providersData{
+		providers: map[providerKey]providerData{
+			{
+				valueType:      reflect.TypeOf(int(0)),
+				annotationType: reflect.TypeOf(Annotation1{}),
+			}: {
+				provider: reflect.ValueOf(func() (int, Annotation1, error) {
+					return testValue, Annotation1{}, nil
+				}),
+				arguments: []providerKey{},
+				hasError:  true,
+			},
+		},
+	})
+	value := self.getInt(Annotation1{})
+	self.Equal(testValue, value)
+}
+
+func (self *InjectorTests) TestGetError() {
+	self.initInjector(&providersData{
+		providers: map[providerKey]providerData{
+			{
+				valueType:      reflect.TypeOf(int(0)),
+				annotationType: reflect.TypeOf(Annotation1{}),
+			}: {
+				provider: reflect.ValueOf(func() (int, Annotation1, error) {
+					return testValue, Annotation1{}, testError
+				}),
+				arguments: []providerKey{},
+				hasError:  true,
+			},
+		},
+	})
+	_, err := self.injector.Get((*int)(nil), Annotation1{})
+	self.Equal(testError, err.(provideError).cause)
+}
+
+func (self *InjectorTests) TestPanic() {
+	self.initInjector(&providersData{
+		providers: map[providerKey]providerData{
+			{
+				valueType:      reflect.TypeOf(int(0)),
+				annotationType: reflect.TypeOf(Annotation1{}),
+			}: {
+				provider: reflect.ValueOf(func() (int, Annotation1) {
+					panic(testError)
+					return 0, Annotation1{}
+				}),
+				arguments: []providerKey{},
+				hasError:  false,
+			},
+		},
+	})
+	self.PanicsWithValue(testError, func() {
+		self.getInt(Annotation1{})
+	})
+}
+
 func (self *InjectorTests) TestGetLazy() {
 	self.initInjector(&providersData{
 		providers: map[providerKey]providerData{
@@ -188,6 +247,40 @@ func (self *InjectorTests) TestGetLazyError() {
 	self.Equal(testError, err.(provideError).cause.(provideError).cause)
 }
 
+// func (self *InjectorTests) TestGetLazyPanic() {
+// 	self.initInjector(&providersData{
+// 		providers: map[providerKey]providerData{
+// 			{
+// 				valueType:      reflect.TypeOf(int(0)),
+// 				annotationType: reflect.TypeOf(Annotation1{}),
+// 			}: {
+// 				provider: reflect.ValueOf(func() (int, Annotation1) {
+// 					panic(testError)
+// 					return 0, Annotation1{}
+// 				}),
+// 				arguments: []providerKey{},
+// 				hasError:  false,
+// 			},
+// 			{
+// 				valueType:      reflect.TypeOf(int(0)),
+// 				annotationType: reflect.TypeOf(Annotation2{}),
+// 			}: {
+// 				provider: reflect.ValueOf(func(value func() int, _ Annotation1) (int, Annotation2) {
+// 					return value(), Annotation2{}
+// 				}),
+// 				arguments: []providerKey{{
+// 					valueType:      reflect.TypeOf(func() int { return 0 }),
+// 					annotationType: reflect.TypeOf(Annotation1{}),
+// 				}},
+// 				hasError: false,
+// 			},
+// 		},
+// 	})
+// 	self.PanicsWithValue(testError, func() {
+// 		self.injector.Get(new(int), Annotation2{})
+// 	})
+// }
+
 func (self *InjectorTests) TestGetLazyDoesNotCallProviderUntilRequested() {
 	calledLazyProvider := false
 	self.initInjector(&providersData{
@@ -281,44 +374,6 @@ func (self *InjectorTests) TestGetLazyCached() {
 	})
 	self.Equal(testValue, self.getInt(Annotation2{}))
 	self.Equal(testValue, self.getInt(Annotation2{}))
-}
-
-func (self *InjectorTests) TestErrorGet() {
-	self.initInjector(&providersData{
-		providers: map[providerKey]providerData{
-			{
-				valueType:      reflect.TypeOf(int(0)),
-				annotationType: reflect.TypeOf(Annotation1{}),
-			}: {
-				provider: reflect.ValueOf(func() (int, Annotation1, error) {
-					return testValue, Annotation1{}, nil
-				}),
-				arguments: []providerKey{},
-				hasError:  true,
-			},
-		},
-	})
-	value := self.getInt(Annotation1{})
-	self.Equal(testValue, value)
-}
-
-func (self *InjectorTests) TestGetError() {
-	self.initInjector(&providersData{
-		providers: map[providerKey]providerData{
-			{
-				valueType:      reflect.TypeOf(int(0)),
-				annotationType: reflect.TypeOf(Annotation1{}),
-			}: {
-				provider: reflect.ValueOf(func() (int, Annotation1, error) {
-					return testValue, Annotation1{}, testError
-				}),
-				arguments: []providerKey{},
-				hasError:  true,
-			},
-		},
-	})
-	_, err := self.injector.Get((*int)(nil), Annotation1{})
-	self.Equal(testError, err.(provideError).cause)
 }
 
 func (self *InjectorTests) TestGetTransitive() {

--- a/injector_test.go
+++ b/injector_test.go
@@ -140,7 +140,6 @@ func (self *InjectorTests) TestPanic() {
 			}: {
 				provider: reflect.ValueOf(func() (int, Annotation1) {
 					panic(testError)
-					return 0, Annotation1{}
 				}),
 				arguments: []providerKey{},
 				hasError:  false,
@@ -336,7 +335,6 @@ func (self *InjectorTests) TestGetLazyPanic() {
 			}: {
 				provider: reflect.ValueOf(func() (int, Annotation1) {
 					panic(testError)
-					return 0, Annotation1{}
 				}),
 				arguments: []providerKey{},
 				hasError:  false,


### PR DESCRIPTION
Inject a function instead of a value for any provider. The provider then will not be called until the function is called explicitly.