### PR TITLE
Roll back dynamic annotations in favor of dynamic provider modules.

### DIFF
--- a/auto.go
+++ b/auto.go
@@ -66,7 +66,7 @@ func buildProvidersForAutoInjectModule(module autoInjectModule, providers *provi
 	}
 	extractAnnotations(module.annotations, annotationByField)
 
-	arguments := []providerArgument{}
+	arguments := []providerKey{}
 	providerArgumentTypes := []reflect.Type{}
 	for i := 0; i < key.valueType.NumField(); i += 1 {
 		field := key.valueType.Field(i)
@@ -74,10 +74,10 @@ func buildProvidersForAutoInjectModule(module autoInjectModule, providers *provi
 		if !ok {
 			annotationType = autoAnnotationType
 		}
-		arguments = append(arguments, providerArgument{providerKey{
+		arguments = append(arguments, providerKey{
 			valueType:      field.Type,
 			annotationType: annotationType,
-		}, nil})
+		})
 		providerArgumentTypes = append(providerArgumentTypes, field.Type, annotationType)
 	}
 

--- a/injector.go
+++ b/injector.go
@@ -88,8 +88,7 @@ func (self *Injector) get(key providerKey) (interface{}, error) {
 
 	arguments := make([]reflect.Value, len(provider.arguments)*2)
 	injectionTime := true
-	for index, argument := range provider.arguments {
-		argumentKey := argument.key
+	for index, argumentKey := range provider.arguments {
 		offset := index * 2
 		if lazyArgumentType := getLazyArgumentType(argumentKey); lazyArgumentType != nil {
 			strictArgumentKey := providerKey{valueType: lazyArgumentType, annotationType: argumentKey.annotationType}
@@ -105,17 +104,13 @@ func (self *Injector) get(key providerKey) (interface{}, error) {
 				return []reflect.Value{reflect.ValueOf(result)}
 			})
 		} else {
-			argumentValue, err := self.getCached(argumentKey)
+			argument, err := self.getCached(argumentKey)
 			if err != nil {
 				return nil, provideError{key: key, cause: err}
 			}
-			arguments[offset] = getValueForArgument(argumentValue, argumentKey.valueType)
+			arguments[offset] = getValueForArgument(argument, argumentKey.valueType)
 		}
-		annotationType := argument.originalAnnotationType
-		if annotationType == nil {
-			annotationType = argumentKey.annotationType
-		}
-		arguments[offset+1] = reflect.Zero(annotationType)
+		arguments[offset+1] = reflect.Zero(argumentKey.annotationType)
 	}
 
 	outputs, err := callProviderHandlingLazyErrors(provider.provider, arguments)

--- a/injector_test.go
+++ b/injector_test.go
@@ -41,10 +41,10 @@ func (self *InjectorTests) TestNotFoundTransitive() {
 				provider: reflect.ValueOf(func(_ int, _ Annotation2) (int, Annotation1) {
 					return testValue, Annotation1{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(int(0)),
 					annotationType: reflect.TypeOf(Annotation2{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -65,7 +65,7 @@ func (self *InjectorTests) TestGet() {
 				provider: reflect.ValueOf(func() (int, Annotation1) {
 					return testValue, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 		},
@@ -84,7 +84,7 @@ func (self *InjectorTests) TestGetNil() {
 				provider: reflect.ValueOf(func() (*int, Annotation1) {
 					return nil, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 		},
@@ -103,7 +103,7 @@ func (self *InjectorTests) TestErrorGet() {
 				provider: reflect.ValueOf(func() (int, Annotation1, error) {
 					return testValue, Annotation1{}, nil
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  true,
 			},
 		},
@@ -122,7 +122,7 @@ func (self *InjectorTests) TestGetError() {
 				provider: reflect.ValueOf(func() (int, Annotation1, error) {
 					return testValue, Annotation1{}, testError
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  true,
 			},
 		},
@@ -141,7 +141,7 @@ func (self *InjectorTests) TestPanic() {
 				provider: reflect.ValueOf(func() (int, Annotation1) {
 					panic(testError)
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 		},
@@ -165,7 +165,7 @@ func (self *InjectorTests) TestCachedGet() {
 					}()
 					return counter, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 				cached:    true,
 			},
@@ -185,7 +185,7 @@ func (self *InjectorTests) TestGetTransitiveError() {
 				provider: reflect.ValueOf(func() (int, Annotation1, error) {
 					return testValue, Annotation1{}, testError
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  true,
 			},
 			{
@@ -195,10 +195,10 @@ func (self *InjectorTests) TestGetTransitiveError() {
 				provider: reflect.ValueOf(func(value int, _ Annotation1) (int, Annotation2) {
 					return value * 2, Annotation2{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(int(0)),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -221,7 +221,7 @@ func (self *InjectorTests) TestGetRecalculates() {
 					}()
 					return counter, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 		},
@@ -229,40 +229,6 @@ func (self *InjectorTests) TestGetRecalculates() {
 	self.Equal(testValue, self.getInt(Annotation1{}))
 	self.Equal(testValue+1, self.getInt(Annotation1{}))
 	self.Equal(testValue+2, self.getInt(Annotation1{}))
-}
-
-func (self *InjectorTests) TestGetWithOriginalAnnotation() {
-	self.initInjector(&providersData{
-		providers: map[providerKey]providerData{
-			{
-				valueType:      reflect.TypeOf(int(0)),
-				annotationType: reflect.TypeOf(Annotation1{}),
-			}: {
-				provider: reflect.ValueOf(func() (int, Annotation1) {
-					return testValue, Annotation1{}
-				}),
-				arguments: []providerArgument{},
-				hasError:  false,
-			},
-			{
-				valueType:      reflect.TypeOf(int(0)),
-				annotationType: reflect.TypeOf(Annotation2{}),
-			}: {
-				provider: reflect.ValueOf(func(value int, _ Annotation3) (int, Annotation2) {
-					return value * 2, Annotation2{}
-				}),
-				arguments: []providerArgument{{
-					key: providerKey{
-						valueType:      reflect.TypeOf(int(0)),
-						annotationType: reflect.TypeOf(Annotation1{}),
-					},
-					originalAnnotationType: reflect.TypeOf(Annotation3{}),
-				}},
-				hasError: false,
-			},
-		},
-	})
-	self.Equal(testValue*2, self.getInt(Annotation2{}))
 }
 
 func (self *InjectorTests) TestGetLazy() {
@@ -275,7 +241,7 @@ func (self *InjectorTests) TestGetLazy() {
 				provider: reflect.ValueOf(func() (int, Annotation1) {
 					return testValue, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 			{
@@ -285,10 +251,10 @@ func (self *InjectorTests) TestGetLazy() {
 				provider: reflect.ValueOf(func(value func() int, _ Annotation1) (int, Annotation2) {
 					return value(), Annotation2{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(func() int { return 0 }),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -307,7 +273,7 @@ func (self *InjectorTests) TestGetLazyNil() {
 				provider: reflect.ValueOf(func() (*int, Annotation1) {
 					return nil, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 			{
@@ -317,10 +283,10 @@ func (self *InjectorTests) TestGetLazyNil() {
 				provider: reflect.ValueOf(func(value func() *int, _ Annotation1) (*int, Annotation2) {
 					return value(), Annotation2{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(func() *int { return nil }),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -338,7 +304,7 @@ func (self *InjectorTests) TestGetLazyError() {
 				provider: reflect.ValueOf(func() (int, Annotation1, error) {
 					return 0, Annotation1{}, testError
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  true,
 			},
 			{
@@ -348,10 +314,10 @@ func (self *InjectorTests) TestGetLazyError() {
 				provider: reflect.ValueOf(func(value func() int, _ Annotation1) (int, Annotation2) {
 					return value(), Annotation2{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(func() int { return 0 }),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -370,7 +336,7 @@ func (self *InjectorTests) TestGetLazyPanic() {
 				provider: reflect.ValueOf(func() (int, Annotation1) {
 					panic(testError)
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 			{
@@ -380,10 +346,10 @@ func (self *InjectorTests) TestGetLazyPanic() {
 				provider: reflect.ValueOf(func(value func() int, _ Annotation1) (int, Annotation2) {
 					return value(), Annotation2{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(func() int { return 0 }),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -405,7 +371,7 @@ func (self *InjectorTests) TestGetLazyDoesNotCallProviderUntilRequested() {
 					calledLazyProvider = true
 					return testValue, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 			{
@@ -415,10 +381,10 @@ func (self *InjectorTests) TestGetLazyDoesNotCallProviderUntilRequested() {
 				provider: reflect.ValueOf(func(value func() int, _ Annotation1) (int, Annotation2) {
 					return 1, Annotation2{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(func() int { return 0 }),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -441,7 +407,7 @@ func (self *InjectorTests) TestGetLazyCached() {
 					}()
 					return counter, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 				cached:    true,
 			},
@@ -452,10 +418,10 @@ func (self *InjectorTests) TestGetLazyCached() {
 				provider: reflect.ValueOf(func(value func() int, _ Annotation1) (int, Annotation2) {
 					return value(), Annotation2{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(func() int { return 0 }),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -475,7 +441,7 @@ func (self *InjectorTests) TestCallStoredLazyProvider() {
 				provider: reflect.ValueOf(func() (int, Annotation1) {
 					return testValue, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 			{
@@ -486,10 +452,10 @@ func (self *InjectorTests) TestCallStoredLazyProvider() {
 					lazyProvider = value
 					return testValue + 1, Annotation2{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(func() int { return 0 }),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -511,7 +477,7 @@ func (self *InjectorTests) TestProvideFunctionAlias() {
 				provider: reflect.ValueOf(func() (FuncAlias, Annotation1) {
 					return func() int { return testValue }, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 			{
@@ -521,10 +487,10 @@ func (self *InjectorTests) TestProvideFunctionAlias() {
 				provider: reflect.ValueOf(func(value FuncAlias, _ Annotation1) (FuncAlias, Annotation2) {
 					return func() int { return value() + 1 }, Annotation2{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(FuncAlias(nil)),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -547,7 +513,7 @@ func (self *InjectorTests) TestGetTransitive() {
 				provider: reflect.ValueOf(func() (int, Annotation1) {
 					return testValue, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 			{
@@ -557,10 +523,10 @@ func (self *InjectorTests) TestGetTransitive() {
 				provider: reflect.ValueOf(func(value int, _ Annotation1) (int, Annotation2) {
 					return value * 2, Annotation2{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(int(0)),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -579,7 +545,7 @@ func (self *InjectorTests) TestGetTransitiveMultiple() {
 				provider: reflect.ValueOf(func() (int, Annotation1) {
 					return testValue, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 			{
@@ -589,7 +555,7 @@ func (self *InjectorTests) TestGetTransitiveMultiple() {
 				provider: reflect.ValueOf(func() (int, Annotation2) {
 					return testValue * 2, Annotation2{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 			{
@@ -600,13 +566,13 @@ func (self *InjectorTests) TestGetTransitiveMultiple() {
 					value2 int, _ Annotation2) (int, Annotation3) {
 					return value1 + value2, Annotation3{}
 				}),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(int(0)),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}, {providerKey{
+				}, {
 					valueType:      reflect.TypeOf(int(0)),
 					annotationType: reflect.TypeOf(Annotation2{}),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -625,7 +591,7 @@ func (self *InjectorTests) TestMustGet() {
 				provider: reflect.ValueOf(func() (int, Annotation1) {
 					return testValue, Annotation1{}
 				}),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 		},

--- a/providers.go
+++ b/providers.go
@@ -11,14 +11,9 @@ type providerKey struct {
 	annotationType reflect.Type
 }
 
-type providerArgument struct {
-	key                    providerKey
-	originalAnnotationType reflect.Type
-}
-
 type providerData struct {
 	provider  reflect.Value
-	arguments []providerArgument
+	arguments []providerKey
 	hasError  bool
 	cached    bool
 }
@@ -46,13 +41,12 @@ func buildProviders(module Module) (*providersData, error) {
 }
 
 type internalProviderData struct {
-	provider           reflect.Value
-	output             providerKey
-	arguments          []providerArgument
-	module             Module
-	hasError           bool
-	cached             bool
-	annotationProvider bool
+	provider  reflect.Value
+	output    providerKey
+	arguments []providerKey
+	module    Module
+	hasError  bool
+	cached    bool
 }
 
 type moduleProvidersData struct {
@@ -65,12 +59,7 @@ func buildProvidersForLeafModule(module Module, providers *providersData) error 
 	if err != nil {
 		return err
 	}
-	moduleProviders = resolveAnnotationProviders(moduleProviders)
 	for _, provider := range moduleProviders.providers {
-		if provider.annotationProvider {
-			continue
-		}
-
 		if existingProvider, ok := providers.providers[provider.output]; ok {
 			if !reflect.DeepEqual(existingProvider.provider, provider.provider) {
 				return fmt.Errorf(
@@ -98,23 +87,20 @@ func buildModuleProvidersForLeafModule(module Module) (*moduleProvidersData, err
 		method := moduleValue.Method(methodIndex)
 		methodDefinition := moduleType.Method(methodIndex)
 		if !isProvider(method, methodDefinition) &&
-			!isProviderWithError(method, methodDefinition) &&
-			!isAnnotationProvider(method, methodDefinition) {
+			!isProviderWithError(method, methodDefinition) {
 			return nil, fmt.Errorf(
 				"%#v is not a module: it has an invalid provider %#v.",
 				module, method)
 		}
 
 		methodType := method.Type()
-		arguments := make([]providerArgument, 0, methodType.NumIn()/2)
+		arguments := make([]providerKey, 0, methodType.NumIn()/2)
 		for inputIndex := 0; inputIndex < methodType.NumIn(); inputIndex += 2 {
 			valueInput := methodType.In(inputIndex)
 			annotationInput := methodType.In(inputIndex + 1)
-			arguments = append(arguments, providerArgument{
-				key: providerKey{
-					valueType:      valueInput,
-					annotationType: annotationInput,
-				},
+			arguments = append(arguments, providerKey{
+				valueType:      valueInput,
+				annotationType: annotationInput,
 			})
 		}
 
@@ -127,73 +113,15 @@ func buildModuleProvidersForLeafModule(module Module) (*moduleProvidersData, err
 		}
 
 		providers.providers[key] = internalProviderData{
-			hasError:           methodType.NumOut() == 3,
-			module:             module,
-			provider:           method,
-			output:             key,
-			arguments:          arguments,
-			cached:             strings.HasPrefix(methodDefinition.Name, cachedProviderPrefix),
-			annotationProvider: strings.HasPrefix(methodDefinition.Name, annotationProviderPrefix),
+			hasError:  methodType.NumOut() == 3,
+			module:    module,
+			provider:  method,
+			output:    key,
+			arguments: arguments,
+			cached:    strings.HasPrefix(methodDefinition.Name, cachedProviderPrefix),
 		}
 	}
 	return &providers, nil
-}
-
-func resolveAnnotationProviders(inputProviders *moduleProvidersData) *moduleProvidersData {
-	providers := moduleProvidersData{
-		providers: map[providerKey]internalProviderData{},
-	}
-	providedAnnotations := map[reflect.Type]reflect.Type{}
-	for _, provider := range inputProviders.providers {
-		if !provider.annotationProvider {
-			continue
-		}
-
-		result := provider.provider.Call([]reflect.Value{})
-		providedAnnotations[provider.output.annotationType] = reflect.TypeOf(result[0].Interface())
-	}
-	for _, provider := range inputProviders.providers {
-		if provider.annotationProvider {
-			continue
-		}
-
-		arguments := make([]providerArgument, 0, len(provider.arguments))
-		for _, argument := range provider.arguments {
-			arguments = append(arguments, providerArgument{
-				key: providerKey{
-					valueType:      argument.key.valueType,
-					annotationType: replaceAnnotation(argument.key.annotationType, providedAnnotations),
-				},
-				originalAnnotationType: getOriginalAnnotation(argument.key.annotationType, providedAnnotations),
-			})
-		}
-		providers.providers[provider.output] = internalProviderData{
-			output: providerKey{
-				valueType:      provider.output.valueType,
-				annotationType: replaceAnnotation(provider.output.annotationType, providedAnnotations),
-			},
-			arguments: arguments,
-			module:    provider.module,
-			provider:  provider.provider,
-			cached:    provider.cached,
-			hasError:  provider.hasError,
-		}
-	}
-	return &providers
-}
-
-func replaceAnnotation(annotation reflect.Type, providedAnnotations map[reflect.Type]reflect.Type) reflect.Type {
-	if providedAnnotation, ok := providedAnnotations[annotation]; ok {
-		return providedAnnotation
-	}
-	return annotation
-}
-
-func getOriginalAnnotation(annotation reflect.Type, providedAnnotations map[reflect.Type]reflect.Type) reflect.Type {
-	if _, ok := providedAnnotations[annotation]; ok {
-		return annotation
-	}
-	return nil
 }
 
 var globalAnnotationType = reflect.TypeOf((*Annotation)(nil)).Elem()
@@ -201,7 +129,6 @@ var globalErrorType = reflect.TypeOf((*error)(nil)).Elem()
 
 const providerPrefix = "Provide"
 const cachedProviderPrefix = providerPrefix + "Cached"
-const annotationProviderPrefix = providerPrefix + "Annotation"
 
 func isProvider(method reflect.Value, methodDefinition reflect.Method) bool {
 	if !strings.HasPrefix(methodDefinition.Name, providerPrefix) {
@@ -228,21 +155,6 @@ func isProviderWithError(method reflect.Value, methodDefinition reflect.Method) 
 		return false
 	}
 	return hasAnnotationOutput(methodType) && hasInputsWithAnnotations(methodType)
-}
-
-func isAnnotationProvider(method reflect.Value, methodDefinition reflect.Method) bool {
-	if !strings.HasPrefix(methodDefinition.Name, annotationProviderPrefix) {
-		return false
-	}
-
-	methodType := method.Type()
-	if methodType.NumOut() != 2 {
-		return false
-	}
-	if methodType.NumIn() != 0 {
-		return false
-	}
-	return methodType.Out(0) == globalAnnotationType && hasAnnotationOutput(methodType)
 }
 
 func hasAnnotationOutput(methodType reflect.Type) bool {

--- a/providers_test.go
+++ b/providers_test.go
@@ -114,7 +114,7 @@ func (self *BuildProvidersTests) TestIdenticalProviderTwiceActossModules() {
 				annotationType: reflect.TypeOf(int(0)),
 			}: {
 				provider:  reflect.ValueOf(module).MethodByName("Provide"),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 		},
@@ -138,7 +138,7 @@ func (self *BuildProvidersTests) TestValidProviderWithNoArguments() {
 				annotationType: reflect.TypeOf(int64(0)),
 			}: {
 				provider:  reflect.ValueOf(module).MethodByName("Provide"),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 		},
@@ -162,10 +162,10 @@ func (self *BuildProvidersTests) TestValidProviderWithArgument() {
 				annotationType: reflect.TypeOf(int64(0)),
 			}: {
 				provider: reflect.ValueOf(module).MethodByName("Provide"),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(int32(0)),
 					annotationType: reflect.TypeOf(bool(false)),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -189,13 +189,13 @@ func (self *BuildProvidersTests) TestValidProviderWithArguments() {
 				annotationType: reflect.TypeOf(int64(0)),
 			}: {
 				provider: reflect.ValueOf(module).MethodByName("Provide"),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(int32(0)),
 					annotationType: reflect.TypeOf(bool(false)),
-				}, nil}, {providerKey{
+				}, {
 					valueType:      reflect.TypeOf(int64(0)),
 					annotationType: reflect.TypeOf(string("")),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -219,7 +219,7 @@ func (self *BuildProvidersTests) TestValidErrorProvider() {
 				annotationType: reflect.TypeOf(int64(0)),
 			}: {
 				provider:  reflect.ValueOf(module).MethodByName("Provide"),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  true,
 			},
 		},
@@ -247,7 +247,7 @@ func (self *BuildProvidersTests) TestTwoValidProviders() {
 				annotationType: reflect.TypeOf(int64(0)),
 			}: {
 				provider:  reflect.ValueOf(module).MethodByName("Provide1"),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 			{
@@ -255,10 +255,10 @@ func (self *BuildProvidersTests) TestTwoValidProviders() {
 				annotationType: reflect.TypeOf(bool(false)),
 			}: {
 				provider: reflect.ValueOf(module).MethodByName("Provide2"),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(int32(0)),
 					annotationType: reflect.TypeOf(int64(0)),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -289,7 +289,7 @@ func (self *BuildProvidersTests) TestValidProvidersInDifferentModules() {
 				annotationType: reflect.TypeOf(int64(0)),
 			}: {
 				provider:  reflect.ValueOf(module1).MethodByName("Provide1"),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 			},
 			{
@@ -297,10 +297,10 @@ func (self *BuildProvidersTests) TestValidProvidersInDifferentModules() {
 				annotationType: reflect.TypeOf(bool(false)),
 			}: {
 				provider: reflect.ValueOf(module2).MethodByName("Provide2"),
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(int32(0)),
 					annotationType: reflect.TypeOf(int64(0)),
-				}, nil}},
+				}},
 				hasError: false,
 			},
 		},
@@ -324,71 +324,9 @@ func (self *BuildProvidersTests) TestCachedProvider() {
 				annotationType: reflect.TypeOf(int64(0)),
 			}: {
 				provider:  reflect.ValueOf(module).MethodByName("ProvideCachedValue"),
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 				hasError:  false,
 				cached:    true,
-			},
-		},
-	}, providers)
-}
-
-type injectedAnnotation1 struct{}
-type injectedAnnotation2 struct{}
-type injectedAnnotation3 struct{}
-
-type testInjectedAnnotationsModule struct {
-	annotation1 Annotation
-	annotation2 Annotation
-	annotation3 Annotation
-}
-
-func (self *testInjectedAnnotationsModule) Provide(
-	value1 int, _ injectedAnnotation1,
-	value2 int, _ injectedAnnotation2,
-) (int, injectedAnnotation3) {
-	return value1 + value2, injectedAnnotation3{}
-}
-
-func (self *testInjectedAnnotationsModule) ProvideAnnotation1() (Annotation, injectedAnnotation1) {
-	return self.annotation1, injectedAnnotation1{}
-}
-
-func (self *testInjectedAnnotationsModule) ProvideAnnotation2() (Annotation, injectedAnnotation2) {
-	return self.annotation2, injectedAnnotation2{}
-}
-
-func (self *testInjectedAnnotationsModule) ProvideAnnotation3() (Annotation, injectedAnnotation3) {
-	return self.annotation3, injectedAnnotation3{}
-}
-
-func (self *BuildProvidersTests) TestInjectedAnnotations() {
-	module := &testInjectedAnnotationsModule{
-		annotation1: Annotation1{},
-		annotation2: Annotation2{},
-		annotation3: Annotation3{},
-	}
-	providers, err := buildProviders(module)
-	self.Require().Nil(err)
-	self.Equal(&providersData{
-		providers: map[providerKey]providerData{
-			{
-				valueType:      reflect.TypeOf(int(0)),
-				annotationType: reflect.TypeOf(Annotation3{}),
-			}: {
-				provider: reflect.ValueOf(module).MethodByName("Provide"),
-				arguments: []providerArgument{{
-					key: providerKey{
-						valueType:      reflect.TypeOf(int(0)),
-						annotationType: reflect.TypeOf(Annotation1{}),
-					},
-					originalAnnotationType: reflect.TypeOf(injectedAnnotation1{}),
-				}, {
-					key: providerKey{
-						valueType:      reflect.TypeOf(int(0)),
-						annotationType: reflect.TypeOf(Annotation2{}),
-					}, originalAnnotationType: reflect.TypeOf(injectedAnnotation2{}),
-				}},
-				hasError: false,
 			},
 		},
 	}, providers)
@@ -405,7 +343,7 @@ func (self *BuildProvidersTests) TestAutoInjectEmptyStruct() {
 				valueType:      reflect.TypeOf(Struct{}),
 				annotationType: reflect.TypeOf(Annotation1{}),
 			}: {
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 			},
 		},
 	}, providers)
@@ -433,28 +371,28 @@ func (self *BuildProvidersTests) TestAutoInjectStructAuto() {
 				valueType:      reflect.TypeOf(Struct1{}),
 				annotationType: reflect.TypeOf(Auto{}),
 			}: {
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 			},
 			{
 				valueType:      reflect.TypeOf(Struct2{}),
 				annotationType: reflect.TypeOf(Auto{}),
 			}: {
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(Struct1{}),
 					annotationType: reflect.TypeOf(Auto{}),
-				}, nil}},
+				}},
 			},
 			{
 				valueType:      reflect.TypeOf(Struct3{}),
 				annotationType: reflect.TypeOf(Auto{}),
 			}: {
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(Struct1{}),
 					annotationType: reflect.TypeOf(Auto{}),
-				}, nil}, {providerKey{
+				}, {
 					valueType:      reflect.TypeOf(Struct2{}),
 					annotationType: reflect.TypeOf(Auto{}),
-				}, nil}},
+				}},
 			},
 		},
 	}, providers)
@@ -487,28 +425,28 @@ func (self *BuildProvidersTests) TestAutoInjectStructCustomAnnotations() {
 				valueType:      reflect.TypeOf(Struct1{}),
 				annotationType: reflect.TypeOf(Annotation1{}),
 			}: {
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 			},
 			{
 				valueType:      reflect.TypeOf(Struct2{}),
 				annotationType: reflect.TypeOf(Annotation2{}),
 			}: {
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(Struct1{}),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 			},
 			{
 				valueType:      reflect.TypeOf(Struct3{}),
 				annotationType: reflect.TypeOf(Annotation3{}),
 			}: {
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(Struct1{}),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}, {providerKey{
+				}, {
 					valueType:      reflect.TypeOf(Struct2{}),
 					annotationType: reflect.TypeOf(Annotation2{}),
-				}, nil}},
+				}},
 			},
 		},
 	}, providers)
@@ -550,28 +488,28 @@ func (self *BuildProvidersTests) TestAutoInjectStructDefaultAnnotations() {
 				valueType:      reflect.TypeOf(Struct1Default{}),
 				annotationType: reflect.TypeOf(Annotation1{}),
 			}: {
-				arguments: []providerArgument{},
+				arguments: []providerKey{},
 			},
 			{
 				valueType:      reflect.TypeOf(Struct2Default{}),
 				annotationType: reflect.TypeOf(Annotation2{}),
 			}: {
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(Struct1Default{}),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}},
+				}},
 			},
 			{
 				valueType:      reflect.TypeOf(Struct3Default{}),
 				annotationType: reflect.TypeOf(Annotation3{}),
 			}: {
-				arguments: []providerArgument{{providerKey{
+				arguments: []providerKey{{
 					valueType:      reflect.TypeOf(Struct1Default{}),
 					annotationType: reflect.TypeOf(Annotation1{}),
-				}, nil}, {providerKey{
+				}, {
 					valueType:      reflect.TypeOf(Struct2Default{}),
 					annotationType: reflect.TypeOf(Annotation2{}),
-				}, nil}},
+				}},
 			},
 		},
 	}, providers)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -160,48 +160,6 @@ func (self testValuesModule) ProvideValue2() (int, Annotation2) {
 	return testValue + 1, Annotation2{}
 }
 
-type testInjectedAnnotation struct{}
-
-type testDynamicAnnotationModule struct {
-	annotation inject.Annotation
-}
-
-func (self testDynamicAnnotationModule) ProvideDouble(
-	value int, _ testInjectedAnnotation,
-) (int64, testInjectedAnnotation) {
-	return int64(value) * 2, testInjectedAnnotation{}
-}
-
-func (self testDynamicAnnotationModule) ProvideAnnotation() (inject.Annotation, testInjectedAnnotation) {
-	return self.annotation, testInjectedAnnotation{}
-}
-
-type testSumModule struct{}
-
-func (self testSumModule) ProvideSum(
-	value1 int64, _ Annotation1,
-	value2 int64, _ Annotation2,
-) (int64, Annotation3) {
-	return value1 + value2, Annotation3{}
-}
-
-func (self *IntegrationTests) TestDynamicAnnotations() {
-	injector, err := inject.InjectorOf(
-		testValuesModule{},
-		testDynamicAnnotationModule{Annotation1{}},
-		testDynamicAnnotationModule{Annotation2{}},
-		testSumModule{},
-	)
-	self.Require().Nil(err)
-
-	value1 := injector.MustGet(new(int64), Annotation1{}).(int64)
-	value2 := injector.MustGet(new(int64), Annotation2{}).(int64)
-	value3 := injector.MustGet(new(int64), Annotation3{}).(int64)
-	self.Equal(int64(testValue*2), value1)
-	self.Equal(int64((testValue+1)*2), value2)
-	self.Equal(int64(value1+value2), value3)
-}
-
 func (self *IntegrationTests) TestAutoInject() {
 	type Struct1 struct {
 		Value1 int


### PR DESCRIPTION
Related to #17.

Rolls back #7.